### PR TITLE
Added additional option for displaying error dialogues on logged error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Currently, there are four different formats supported.
 
 ```
 m ToExcelIndex FromSheetIndex ToSheetIndex
-n name
+n mappingName
 c configSwitch
 ax ay bx by
 ax ay bx by rep
@@ -130,7 +130,7 @@ Every line starting by `m` starts a new mapping to the specified TO excel file.
 + `ToExcelIndex`: Which TO excel file that should be used. The first file has the index 0.
 + `FromSheetIndex`: The sheet number in the FROM excel file that should be used to lookup cells. The first sheet has the index 0.
 + `ToSheetIndex`: The sheet number in the TO excel file that should be used to lookup cells. The first sheet has the index 0.
-+ `name`: user defined name for the mapping that will be displayed on error dialogues, may contain whitespace characters.
++ `mappingName`: user defined name for the mapping that will be displayed on error dialogues, may contain whitespace characters.
 + `configSwitch`: Config switch to be turned on for current mapping block.
 + `ax`: The row cell index of a FROM excel file. Starts counting at zero. The excel index 1 or A respectively gets mapped to the index 0.
 + `ay`: The column cell index of a FROM excel file. The excel index 1 or A respectively gets mapped to the index 0.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following legend describes a list of all expected `<CONFIG_NAME>` entries an
 
 + `debug_mod`: Is either `0` (run debug mode) or `1` (run normal mode). Running the debug mode will basically print the content of the input excel file. Running the normal mode will start the GUI application as expected.
 + `use logger`: In case this option is set to `1`, then logger statements are streamed to the terminal. Otherwise it is muted.
++ `show_error_dialogue`: In case this option is set to `1`the application will display a dialogue every time the application logs an error which lets the user abort the mapping operation
 + `base_from_lookup_path`: Starting directory displayed when running the gui and searching for a FROM excel file. Paths are enclosed by quotes (to handle white spaces in paths)
 + `base_to_lookup_path`: Starting directory displayed when running the gui and searching for a TO excel file. Paths are enclosed by quotes (to handle white spaces in paths)
 
@@ -87,6 +88,7 @@ In the following an eample that:
 
 + Does not run the program in the debug mode
 + Does not print logging statements in the terminal
++ Displays an error dialogue on logged error messages
 + Uses the following base paths:
  + FROM base path: `foobar/`
  + TO base path: `barbaz/`
@@ -95,6 +97,7 @@ In the following an eample that:
 
 debug_mode: 0
 use_logger: 0
+show_error_dialogue: 1
 use_base_paths: 1
 base_from_lookup_path: "foobar/"
 base_to_lookup_path: "barbaz/"
@@ -109,6 +112,7 @@ Currently, there are four different formats supported.
 
 ```
 m ToExcelIndex FromSheetIndex ToSheetIndex
+n name
 c configSwitch
 ax ay bx by
 ax ay bx by rep
@@ -126,6 +130,7 @@ Every line starting by `m` starts a new mapping to the specified TO excel file.
 + `ToExcelIndex`: Which TO excel file that should be used. The first file has the index 0.
 + `FromSheetIndex`: The sheet number in the FROM excel file that should be used to lookup cells. The first sheet has the index 0.
 + `ToSheetIndex`: The sheet number in the TO excel file that should be used to lookup cells. The first sheet has the index 0.
++ `name`: user defined name for the mapping that will be displayed on error dialogues, may contain whitespace characters.
 + `configSwitch`: Config switch to be turned on for current mapping block.
 + `ax`: The row cell index of a FROM excel file. Starts counting at zero. The excel index 1 or A respectively gets mapped to the index 0.
 + `ay`: The column cell index of a FROM excel file. The excel index 1 or A respectively gets mapped to the index 0.

--- a/src/main/java/CellMappingBlock.java
+++ b/src/main/java/CellMappingBlock.java
@@ -6,12 +6,14 @@ public class CellMappingBlock {
     public int toSheetIdx;
     public boolean insertAsColumn;
     public boolean requireNonEmptySource;
+    public String name;
     private ArrayList<CellMapping> cellMappings;
     
     public CellMappingBlock(int toExcelIdx, int fromSheetIdx, int toSheetIdx) {
     	this.toExcelIdx = toExcelIdx;
     	this.fromSheetIdx = fromSheetIdx;
     	this.toSheetIdx = toSheetIdx;
+    	this.name = "FROM Sheet " + fromSheetIdx + " TO Sheet " + toSheetIdx + " on TO Excel " + toExcelIdx;
     	cellMappings = new ArrayList<>();
     	insertAsColumn = false;
     	requireNonEmptySource = false;

--- a/src/main/java/Consolidator.java
+++ b/src/main/java/Consolidator.java
@@ -39,6 +39,9 @@ public class Consolidator extends FileReader {
 	            Logger.println("Running in debug mode");
 	            runDebugMode(cellMappingBlock);
 	        }
+	        if(Properties.abortRequested()) {
+	        	break;
+	        }
         }
     }
     
@@ -95,7 +98,7 @@ public class Consolidator extends FileReader {
 
         Logger.println("Using from sheet Index " + cellMappingBlock.fromSheetIdx + " and TO sheet index: " + cellMappingBlock.toSheetIdx + " for performing cell lookups in Excel TO " + cellMappingBlock.toExcelIdx + ".");
         if(cellMappingBlock.requireNonEmptySource && inExcel.hasEmptySourceCells(sublistCellMappings)) {
-			Logger.println("FROM Excel contained empty cells for the given mapping. Did not copy anything for current mapping block.");
+			Logger.printError("FROM Excel contained empty cells for the mapping \"" + cellMappingBlock.name + "\". Did not copy anything for current mapping block.");
         	return;
         }
         int freeToColumn = 0;
@@ -134,6 +137,12 @@ public class Consolidator extends FileReader {
         	cellMappingBlocks.add(new CellMappingBlock(toExcelIdx, fromSheetIdx, toSheetIdx));
         } else {
         	CellMappingBlock currentBlock = cellMappingBlocks.get(cellMappingBlocks.size()-1);
+        	
+        	// name for current cell mapping block
+        	if(row[0].equals("n")) {
+        		currentBlock.name = line.substring(row[0].length()+1);
+        		return;
+        	}
         	
         	// config option for current cell mapping block
         	if(row[0].equals("c")) {

--- a/src/main/java/Gui.java
+++ b/src/main/java/Gui.java
@@ -125,6 +125,11 @@ public class Gui extends Frame {
                     Logger.println(" => Excel files read.");
                     Logger.println("Copying content from FROM excel file to TO files ...");
                     new Consolidator(Properties.getMappingFilePath(), fromExcel, toExcels);
+                    if(Properties.abortRequested()) {
+                        Logger.println(" => User requested to abort copy operations.");
+                        Logger.println("Excel2Excel finished without modifying any files.");
+                    	return;
+                    }
                     Logger.println(" => Content copied.");
 
                     for (int k = 0; k < 2; k++) {

--- a/src/main/java/Logger.java
+++ b/src/main/java/Logger.java
@@ -7,6 +7,8 @@ import java.nio.file.*;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.swing.JOptionPane;
+
 /**
  * A logger is responsible for printing the runtime state of a given execution.
  * It prints a given status report file (to have some reconstructive information).
@@ -75,12 +77,20 @@ public class Logger {
 
     /**
      * Prints an error string in the console if allowed.
+     * Returns true if the user requested to exit the application
      *
      * @param msg given error message.
      */
     public static void printError(String msg) {
         if (getInstance().mayPrint()) System.err.println(msg);
         getInstance().writeBuffer(msg);
+        
+        if(Properties.showErrorDialogue()) {
+        	int return_code = JOptionPane.showConfirmDialog(null, "An error has occured: \"" + msg + "\"\n\nDo you wish to continue anyways?", "Error", JOptionPane.YES_NO_OPTION);
+        	if(return_code == JOptionPane.NO_OPTION) {
+        		Properties.requestAbort();
+        	}
+        }
     }
 
     /**

--- a/src/main/java/Logger.java
+++ b/src/main/java/Logger.java
@@ -77,7 +77,6 @@ public class Logger {
 
     /**
      * Prints an error string in the console if allowed.
-     * Returns true if the user requested to exit the application
      *
      * @param msg given error message.
      */
@@ -86,8 +85,8 @@ public class Logger {
         getInstance().writeBuffer(msg);
         
         if(Properties.showErrorDialogue()) {
-        	int return_code = JOptionPane.showConfirmDialog(null, "An error has occured: \"" + msg + "\"\n\nDo you wish to continue anyways?", "Error", JOptionPane.YES_NO_OPTION);
-        	if(return_code == JOptionPane.NO_OPTION) {
+        	int confirmDialogueState = JOptionPane.showConfirmDialog(null, "An error has occured: \"" + msg + "\"\n\nDo you wish to continue anyways?", "Error", JOptionPane.YES_NO_OPTION);
+        	if(confirmDialogueState == JOptionPane.NO_OPTION) {
         		Properties.requestAbort();
         	}
         }

--- a/src/main/java/Properties.java
+++ b/src/main/java/Properties.java
@@ -25,6 +25,8 @@ public class Properties extends FileReader {
     private static Properties instance;
     private String[] userParameters;
     private HashMap<String, String> properties;
+    
+    private boolean abortRequested;
 
     public static Properties getInstance(String[] userParameters) {
         if (instance == null) {
@@ -71,6 +73,7 @@ public class Properties extends FileReader {
     public Properties(String[] userParameters) {
         this.userParameters = userParameters;
         this.properties = new HashMap<String, String>();
+        this.abortRequested = false;
         readFile(getConfigPath());
     }
 
@@ -174,6 +177,19 @@ public class Properties extends FileReader {
 
     public boolean hasLoadedProperties() {
         return !properties.isEmpty();
+    }
+
+    public static boolean showErrorDialogue() {
+    	String prop = getInstance().properties.get("show_error_dialogue");
+        return prop != null && prop.equals("1");
+    }
+
+    public static boolean abortRequested() {
+        return getInstance().abortRequested;
+    }
+
+    public static void requestAbort() {
+        getInstance().abortRequested = true;
     }
 
     @Override

--- a/src/main/java/Properties.java
+++ b/src/main/java/Properties.java
@@ -180,8 +180,8 @@ public class Properties extends FileReader {
     }
 
     public static boolean showErrorDialogue() {
-    	String prop = getInstance().properties.get("show_error_dialogue");
-        return prop != null && prop.equals("1");
+    	String property = getInstance().properties.get("show_error_dialogue");
+        return property != null && property.equals("1");
     }
 
     public static boolean abortRequested() {


### PR DESCRIPTION
For increased usability of the app for the average person (i. e. someone that did not create the mapping files themselves and are just executing the app) error messages need to be more visible and clear to understand, for that purpose the individual mapping blocks also need to be able to be told apart by such a user, so I've also added the ability to give each mapping block a name that can be referred to in the relevant error messages.

The standard name for a mapping block contains the to Excel, to sheet and from sheet indices.