### PR TITLE
Added a bunch of smaller features and modified some of the subtleties

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Each mapping block starting with `m` may contain any number of lines starting wi
 + `insertAsColumn`: Will insert all the mappings in that block that are set to search for the first free cell in their destination row (i.e. `rep=1`) into the first column that is free for all of them instead.
 + `requireNonEmpty`: Assures that all of the mappings in that block are only executed if all of their source cells aren't empty.
 + `treatFormulaAsBlank`: Treats formula cells in destination file as blank cells.
++ `autoSkipOnError`: Rather than presenting an error dialogue letting the user choose whether to skip the failed mapping it will skip automatically.
 
 
 ### Example
@@ -176,13 +177,13 @@ c insertAsColumn
 
 ## Scale Values Format
 
-This program allows you to translate symbolic cell values to numerical values. 
+This program allows you to translate symbolic cell values to numeric/string values. 
 
 For example, we use the commonly known labels used to represent sexes, `m` (male), `f` (female) and `o` (other) and want to map them
 to numerical values. A particular mapping could be the following: `m` corresponds to `1`, `f` to `2` and `o` maps to `3`.
 
 To do so, one has has to specify which cells should be translated in the `mappings.txt` file (see previous section)
-and define in the `scale_values.txt` file, which symbolic values are translated to which numerical value.
+and define in the `scale_values.txt` file, which symbolic values are translated to which numerical/string value.
 
 The format of the scale_values has the following structure:
 
@@ -194,7 +195,7 @@ Sm1 Sm2 ... Smn Nm1 Nm2 ... Nmn
 
 ```
 
-`Sij` defines a symbolic value and `Nij` its associated numerical value. Therefore, each line consists
+`Sij` defines a symbolic value and `Nij` its associated numerical or string value. Therefore, each line consists
 of `2*k` number of elements (k is the number of symbols).
  
 Items (both, symbolic and numerical values) in the file are white space separated.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Each mapping block starting with `m` may contain any number of lines starting wi
 #### List of Config Switches
 + `insertAsColumn`: Will insert all the mappings in that block that are set to search for the first free cell in their destination row (i.e. `rep=1`) into the first column that is free for all of them instead.
 + `requireNonEmpty`: Assures that all of the mappings in that block are only executed if all of their source cells aren't empty.
++ `treatFormulaAsBlank`: Treats formula cells in destination file as blank cells.
 
 
 ### Example

--- a/src/main/java/CellContent.java
+++ b/src/main/java/CellContent.java
@@ -55,8 +55,8 @@ public class CellContent {
 		}
 	}
 	
-	public boolean isBlank() {
-		if(wasFormula) {
+	public boolean isBlank(boolean treatFormulaAsBlank) {
+		if(!treatFormulaAsBlank && wasFormula) {
 			return false;
 		}
 		
@@ -74,6 +74,10 @@ public class CellContent {
 			default:
 				return false;
 		}
+	}
+	
+	public boolean isBlank() {
+		return isBlank(false);
 	}
 	
 	public String toString() {

--- a/src/main/java/CellContent.java
+++ b/src/main/java/CellContent.java
@@ -55,6 +55,11 @@ public class CellContent {
 		}
 	}
 	
+	public CellContent(double content) {
+		type = CellType.NUMERIC;
+		numeric = content;
+	}
+	
 	public boolean isBlank(boolean treatFormulaAsBlank) {
 		if(!treatFormulaAsBlank && wasFormula) {
 			return false;
@@ -89,6 +94,7 @@ public class CellContent {
 				return String.valueOf(bool);
 				
 			case NUMERIC:
+				//FIXME: eventually we should probably handle numeric types with their cell formatting
 				return String.valueOf(numeric);
 				
 			case STRING:

--- a/src/main/java/CellMappingBlock.java
+++ b/src/main/java/CellMappingBlock.java
@@ -1,22 +1,24 @@
 import java.util.ArrayList;
 
 public class CellMappingBlock {
+    public String name;
 	public int toExcelIdx;
     public int fromSheetIdx;
     public int toSheetIdx;
+    private ArrayList<CellMapping> cellMappings;
     public boolean insertAsColumn;
     public boolean requireNonEmptySource;
-    public String name;
-    private ArrayList<CellMapping> cellMappings;
+    public boolean treatFormulaAsBlank;
     
     public CellMappingBlock(int toExcelIdx, int fromSheetIdx, int toSheetIdx) {
+    	this.name = "FROM Sheet " + fromSheetIdx + " TO Sheet " + toSheetIdx + " on TO Excel " + toExcelIdx;
     	this.toExcelIdx = toExcelIdx;
     	this.fromSheetIdx = fromSheetIdx;
     	this.toSheetIdx = toSheetIdx;
-    	this.name = "FROM Sheet " + fromSheetIdx + " TO Sheet " + toSheetIdx + " on TO Excel " + toExcelIdx;
-    	cellMappings = new ArrayList<>();
-    	insertAsColumn = false;
-    	requireNonEmptySource = false;
+    	this.cellMappings = new ArrayList<>();
+    	this.insertAsColumn = false;
+    	this.requireNonEmptySource = false;
+    	this.treatFormulaAsBlank = false;
     }
     
     public void addMapping(CellMapping cellMapping) {

--- a/src/main/java/CellMappingBlock.java
+++ b/src/main/java/CellMappingBlock.java
@@ -9,6 +9,7 @@ public class CellMappingBlock {
     public boolean insertAsColumn;
     public boolean requireNonEmptySource;
     public boolean treatFormulaAsBlank;
+    public boolean autoSkipOnError;
     
     public CellMappingBlock(int toExcelIdx, int fromSheetIdx, int toSheetIdx) {
     	this.name = "FROM Sheet " + fromSheetIdx + " TO Sheet " + toSheetIdx + " on TO Excel " + toExcelIdx;
@@ -19,6 +20,7 @@ public class CellMappingBlock {
     	this.insertAsColumn = false;
     	this.requireNonEmptySource = false;
     	this.treatFormulaAsBlank = false;
+    	this.autoSkipOnError = false;
     }
     
     public void addMapping(CellMapping cellMapping) {

--- a/src/main/java/Consolidator.java
+++ b/src/main/java/Consolidator.java
@@ -149,16 +149,13 @@ public class Consolidator extends FileReader {
         		if(row[1].equals("insertAsColumn")) {
         			currentBlock.insertAsColumn = true;
         			return;
-        		}
-        		if(row[1].equals("requireNonEmptySource")) {
+        		} else if(row[1].equals("requireNonEmptySource")) {
         			currentBlock.requireNonEmptySource = true;
         			return;
-        		}
-        		if(row[1].equals("treatFormulaAsBlank")) {
+        		} else if(row[1].equals("treatFormulaAsBlank")) {
         			currentBlock.treatFormulaAsBlank = true;
         			return;
-        		}
-        		if(row[1].equals("autoSkipOnError")) {
+        		} else if(row[1].equals("autoSkipOnError")) {
         			currentBlock.autoSkipOnError = true;
         			return;
         		}

--- a/src/main/java/Consolidator.java
+++ b/src/main/java/Consolidator.java
@@ -64,9 +64,10 @@ public class Consolidator extends FileReader {
             if (cellMapping.hasTranslation()) {
             	if(fromValue.type == CellType.STRING) {
             		fromValue.type = CellType.NUMERIC;
-                	fromValue.numeric = Translator.lookup(cellMapping.getTranslationRow(), fromValue.string);
+                	fromValue = Translator.lookup(cellMapping.getTranslationRow(), fromValue.string);
             	} else if(fromValue.type == CellType.NUMERIC) {
-            		fromValue.numeric = Translator.lookup(cellMapping.getTranslationRow(), new DecimalFormat("0.######").format(fromValue.numeric));
+            		//FIXME: currently a bit of a hack, eventually we should probably handle numeric types with their cell formatting
+            		fromValue = Translator.lookup(cellMapping.getTranslationRow(), new DecimalFormat("0.######").format(fromValue.numeric));
             	}
             }
         }

--- a/src/main/java/Consolidator.java
+++ b/src/main/java/Consolidator.java
@@ -62,13 +62,7 @@ public class Consolidator extends FileReader {
         if (!cellMapping.hasDefaultValue()) {
             fromValue = inExcel.getCellValue(cellMapping.getFromRowIndex(), cellMapping.getFromColumnIndex());
             if (cellMapping.hasTranslation()) {
-            	if(fromValue.type == CellType.STRING) {
-            		fromValue.type = CellType.NUMERIC;
-                	fromValue = Translator.lookup(cellMapping.getTranslationRow(), fromValue.string);
-            	} else if(fromValue.type == CellType.NUMERIC) {
-            		//FIXME: currently a bit of a hack, eventually we should probably handle numeric types with their cell formatting
-            		fromValue = Translator.lookup(cellMapping.getTranslationRow(), new DecimalFormat("0.######").format(fromValue.numeric));
-            	}
+            	fromValue = Translator.lookup(cellMapping.getTranslationRow(), fromValue);
             }
         }
         
@@ -104,7 +98,7 @@ public class Consolidator extends FileReader {
 
         Logger.println("Using from sheet Index " + cellMappingBlock.fromSheetIdx + " and TO sheet index: " + cellMappingBlock.toSheetIdx + " for performing cell lookups in Excel TO " + cellMappingBlock.toExcelIdx + ".");
         if(cellMappingBlock.requireNonEmptySource && inExcel.hasEmptySourceCells(sublistCellMappings)) {
-			Logger.printError("FROM Excel contained empty cells for the mapping \"" + cellMappingBlock.name + "\". Did not copy anything for current mapping block.");
+        	Logger.printError("FROM Excel contained empty cells for the mapping \"" + cellMappingBlock.name + "\". Did not copy anything for current mapping block.", cellMappingBlock.autoSkipOnError);
         	return;
         }
         int freeToColumn = 0;
@@ -162,6 +156,10 @@ public class Consolidator extends FileReader {
         		}
         		if(row[1].equals("treatFormulaAsBlank")) {
         			currentBlock.treatFormulaAsBlank = true;
+        			return;
+        		}
+        		if(row[1].equals("autoSkipOnError")) {
+        			currentBlock.autoSkipOnError = true;
         			return;
         		}
         		return;

--- a/src/main/java/Excel.java
+++ b/src/main/java/Excel.java
@@ -24,7 +24,7 @@ public abstract class Excel {
      * @param startColIdx cell column index we want to start our search.
      * @return free column index.
      */
-    public int findEmptyCellColumnAtFixedRow(int rowIdx, int startColIdx) {
+    public int findEmptyCellColumnAtFixedRow(int rowIdx, int startColIdx, boolean treatFormulaAsBlank) {
         int colIdx = startColIdx;
         Cell cell;
         CellContent content;
@@ -37,19 +37,23 @@ public abstract class Excel {
             colIdx++;
             cell = row.getCell(colIdx);
             content = new CellContent(cell);
-        } while(!content.isBlank());
+        } while(!content.isBlank(treatFormulaAsBlank));
         
         return colIdx;
+    }
+    
+    public int findEmptyCellColumnAtFixedRow(int rowIdx, int startColIdx) {
+    	return findEmptyCellColumnAtFixedRow(rowIdx, startColIdx, false);
     }
 
     /**
      * Find the next free destination column index for the given list of mappings.
      */
-    public int findEmptyColumnForMappingBlock(ArrayList<CellMapping> cellMappings) {
+    public int findEmptyColumnForMappingBlock(CellMappingBlock cellMappingBlock) {
         int colIdx = 0;
-        for(CellMapping mapping: cellMappings) {
+        for(CellMapping mapping: cellMappingBlock.getMappings()) {
         	if(mapping.usesOffset()) {
-        		colIdx = Math.max(findEmptyCellColumnAtFixedRow(mapping.getToRowIndex(), mapping.getToColumnIndex()), colIdx);
+        		colIdx = Math.max(findEmptyCellColumnAtFixedRow(mapping.getToRowIndex(), mapping.getToColumnIndex(), cellMappingBlock.treatFormulaAsBlank), colIdx);
         	}
         }
         return colIdx;
@@ -109,7 +113,6 @@ public abstract class Excel {
             cell = row.createCell(columnIdx);
         }
         
-		cell.setCellType(content.type);
         switch(content.type) {
     		case BLANK:
     			break;
@@ -130,6 +133,7 @@ public abstract class Excel {
         		Logger.printError("Cell at column " + columnIdx + " could not be written. Invalid cell content given.");
         		break;
         }
+		cell.setCellType(content.type);
     }
 
     public void setLookupSheetIndex(int sheetIndex) {

--- a/src/main/java/Excel.java
+++ b/src/main/java/Excel.java
@@ -156,6 +156,8 @@ public abstract class Excel {
     		CellContent content = getCellValue(mapping.getFromRowIndex(), mapping.getFromColumnIndex());
     		if(content.isBlank()) {
     			return true;
+    		} else if(mapping.hasTranslation()) {
+    			return Translator.lookup(mapping.getTranslationRow(), content).isBlank();
     		}
     	}
     	return false;

--- a/src/main/java/Excel.java
+++ b/src/main/java/Excel.java
@@ -1,6 +1,7 @@
 import java.util.ArrayList;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 
@@ -112,6 +113,11 @@ public abstract class Excel {
             Logger.printError("Cell at column " + columnIdx + " does yet not exist. Creating new cell...");
             cell = row.createCell(columnIdx);
         }
+        
+    	if(content == null) {
+    		cell.setCellType(CellType.BLANK);
+    		return;
+    	}
         
         switch(content.type) {
     		case BLANK:

--- a/src/main/java/Gui.java
+++ b/src/main/java/Gui.java
@@ -49,7 +49,7 @@ public class Gui extends Frame {
 
         copyFromButton.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent e) {
-                fileDialogCopyFrom = new FileDialog(self, "Choose To Excel File");
+                fileDialogCopyFrom = new FileDialog(self, "Choose From Excel File");
                 if (Properties.hasBaseExcelPaths()) {
                     fileDialogCopyFrom.setDirectory(Properties.normalizedPath(Properties.getInstance().getBaseFromLookupPath()));
                 }
@@ -139,7 +139,7 @@ public class Gui extends Frame {
                     }
                     Logger.println("Excel2Excel successfully finished.");
                 } catch (Exception e) {
-                    Logger.printError(e.getMessage());
+                    Logger.printException(e);
                 }
             }
         });

--- a/src/main/java/Logger.java
+++ b/src/main/java/Logger.java
@@ -91,6 +91,12 @@ public class Logger {
         	}
         }
     }
+    
+    public static void printException(Exception e) {
+    	printError(e.getClass().getSimpleName() + ": " + e.getMessage());
+        if (getInstance().mayPrint()) e.printStackTrace();
+        getInstance().writeBuffer(e.getStackTrace().toString());
+    }
 
     /**
      * Prints a formatted path error.

--- a/src/main/java/Logger.java
+++ b/src/main/java/Logger.java
@@ -80,16 +80,20 @@ public class Logger {
      *
      * @param msg given error message.
      */
-    public static void printError(String msg) {
+    public static void printError(String msg, boolean surpressDialogue) {
         if (getInstance().mayPrint()) System.err.println(msg);
         getInstance().writeBuffer(msg);
         
-        if(Properties.showErrorDialogue()) {
+        if(!surpressDialogue && Properties.showErrorDialogue()) {
         	int confirmDialogueState = JOptionPane.showConfirmDialog(null, "An error has occured: \"" + msg + "\"\n\nDo you wish to continue anyways?", "Error", JOptionPane.YES_NO_OPTION);
         	if(confirmDialogueState == JOptionPane.NO_OPTION) {
         		Properties.requestAbort();
         	}
         }
+    }
+    
+    public static void printError(String msg) {
+    	printError(msg, false);
     }
     
     public static void printException(Exception e) {

--- a/src/main/java/Properties.java
+++ b/src/main/java/Properties.java
@@ -1,4 +1,3 @@
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -109,7 +108,6 @@ public class Properties extends FileReader {
     public static String getToExcelFilePath2() {
         return getInstance().getPathAt(2);
     }
-
 
     public String getPathAt(int idx) {
         return Paths.get(Properties.buildUTF8String(userParameters[idx])).toString();

--- a/src/main/java/Scale.java
+++ b/src/main/java/Scale.java
@@ -19,7 +19,7 @@ public class Scale {
 
     // the values represent the numerical value of a scale.
     // The k-th value element belongs to the k-th label element
-    private ArrayList<Integer> values;
+    private ArrayList<CellContent> values;
 
     /**
      * Form an empty scale which consists of a series of
@@ -27,7 +27,7 @@ public class Scale {
      */
     public Scale() {
         labels = new ArrayList<String>();
-        values = new ArrayList<Integer>();
+        values = new ArrayList<CellContent>();
     }
 
     /**
@@ -37,7 +37,7 @@ public class Scale {
      * @param label symbolic representation of scale values.
      * @param value numeric scale values.
      */
-    public void appendItem(String label, int value) {
+    public void appendItem(String label, CellContent value) {
         if (!labels.contains(label)) {
             labels.add(label);
             values.add(value);
@@ -53,7 +53,7 @@ public class Scale {
      * @return the numeric scale values. -1 indicates that no such symbolic
      *  scale representation has been found.
      */
-    public int getValueByLabel(String queryLabel) {
+    public CellContent getValueByLabel(String queryLabel) {
         int idx = 0;
         for (String label : labels) {
             if (label.equals(queryLabel)) {
@@ -61,6 +61,6 @@ public class Scale {
             }
             idx++;
         }
-        return -1;
+        return null;
     }
 }

--- a/src/main/java/Translator.java
+++ b/src/main/java/Translator.java
@@ -1,4 +1,7 @@
+import java.text.DecimalFormat;
 import java.util.ArrayList;
+
+import org.apache.poi.ss.usermodel.CellType;
 
 /**
  * A Translator offers to translate symbolic values to numeric values
@@ -51,6 +54,17 @@ public class Translator extends FileReader{
         // normalize to be translated string
         String normalizedString = normalizedInputTranslation(toBeTranslated);
         return scale.getValueByLabel(normalizedString);
+    }
+
+    public static CellContent lookup(int lookupRow, CellContent fromValue) {
+    	if(fromValue.type == CellType.STRING) {
+    		fromValue.type = CellType.NUMERIC;
+        	fromValue = Translator.lookup(lookupRow, fromValue.string);
+    	} else if(fromValue.type == CellType.NUMERIC) {
+    		//FIXME: currently a bit of a hack, eventually we should probably handle numeric types with their cell formatting
+    		fromValue = Translator.lookup(lookupRow, new DecimalFormat("0.######").format(fromValue.numeric));
+    	}
+    	return fromValue;
     }
 
     /**

--- a/src/main/java/Translator.java
+++ b/src/main/java/Translator.java
@@ -62,6 +62,8 @@ public class Translator extends FileReader{
         	fromValue = Translator.lookup(lookupRow, fromValue.string);
     	} else if(fromValue.type == CellType.NUMERIC) {
     		//FIXME: currently a bit of a hack, eventually we should probably handle numeric types with their cell formatting
+    		//DecimalFormat rounds the numeric to the number of #, so it will determine some source values equal that shouldn't have been
+    		//it makes more sense to treat the numerics as they appear in the Excel file which is determined by the cell's formatting.
     		fromValue = Translator.lookup(lookupRow, new DecimalFormat("0.######").format(fromValue.numeric));
     	}
     	return fromValue;

--- a/src/main/java/Translator.java
+++ b/src/main/java/Translator.java
@@ -45,7 +45,7 @@ public class Translator extends FileReader{
      * @param toBeTranslated
      * @return
      */
-    public static double lookup(int lookupRow, String toBeTranslated) {
+    public static CellContent lookup(int lookupRow, String toBeTranslated) {
         Scale scale = getInstance().getScales().get(lookupRow);
 
         // normalize to be translated string
@@ -105,7 +105,7 @@ public class Translator extends FileReader{
         Scale scale = new Scale();
         for (int k = 0; k < itemCount; k++) {
             String label = row[k];
-            int value = Integer.parseInt(row[k + itemCount]);
+            CellContent value = new CellContent(row[k + itemCount]);
             scale.appendItem(label, value);
         }
         scales.add(scale);

--- a/src/main/java/XlsExcelFile.java
+++ b/src/main/java/XlsExcelFile.java
@@ -3,6 +3,7 @@ import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.hssf.usermodel.HSSFFormulaEvaluator;
+import java.nio.file.*;
 import java.io.*;
 
 /**
@@ -15,7 +16,7 @@ import java.io.*;
 public class XlsExcelFile extends Excel {
     private HSSFSheet sheet;
     private HSSFWorkbook workbook;
-    private String filePath;
+    private Path filePath;
 
     /**
      * Load a excel file by its path and sheet nr.
@@ -25,11 +26,11 @@ public class XlsExcelFile extends Excel {
      * @param sheetNr relevant sheet inside excel file that should be loaded.
      */
     public XlsExcelFile(String filePath, int sheetNr) {
-        this.filePath = filePath;
+        this.filePath = Paths.get(filePath);
 
-        FileInputStream file = null;
+        InputStream file = null;
         try {
-            file = new FileInputStream(new File(filePath));
+            file = Files.newInputStream(this.filePath, StandardOpenOption.READ);
             workbook = new HSSFWorkbook(file);
         } catch (FileNotFoundException e) {
             e.printStackTrace();
@@ -64,7 +65,7 @@ public class XlsExcelFile extends Excel {
     @Override
     public void save() {
         try {
-            FileOutputStream stream = new FileOutputStream(filePath);
+            OutputStream stream = Files.newOutputStream(filePath, StandardOpenOption.WRITE);
             HSSFFormulaEvaluator.evaluateAllFormulaCells(workbook);
             workbook.write(stream);
         } catch (IOException e) {

--- a/src/main/java/XlsmExcelFile.java
+++ b/src/main/java/XlsmExcelFile.java
@@ -19,7 +19,7 @@ public class XlsmExcelFile extends XlsxExcelFile {
         XSSFWorkbook workbook = null;
         try {
             workbook = new XSSFWorkbook(
-                    OPCPackage.open(filePath)
+                    OPCPackage.open(filePath.toString())
             );
 
         } catch (IOException e) {

--- a/src/main/java/XlsxExcelFile.java
+++ b/src/main/java/XlsxExcelFile.java
@@ -4,6 +4,7 @@ import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFFormulaEvaluator;
 
+import java.nio.file.*;
 import java.io.*;
 
 /**
@@ -16,7 +17,7 @@ import java.io.*;
 public class XlsxExcelFile extends Excel {
     protected XSSFSheet sheet;
     protected XSSFWorkbook workbook;
-    protected String filePath;
+    protected Path filePath;
 
     /**
      * Load a excel file by its path and sheet nr.
@@ -26,7 +27,7 @@ public class XlsxExcelFile extends Excel {
      * @param sheetNr relevant sheet inside excel file that should be loaded.
      */
     public XlsxExcelFile(String filePath, int sheetNr) {
-        this.filePath = filePath;
+        this.filePath = Paths.get(filePath);
         workbook = loadWorkbook();
         setSheetAt(sheetNr);
     }
@@ -34,7 +35,7 @@ public class XlsxExcelFile extends Excel {
     protected XSSFWorkbook loadWorkbook() {
         XSSFWorkbook workbook = null;
         try {
-            FileInputStream file = new FileInputStream(new File(filePath));
+            InputStream file = Files.newInputStream(filePath, StandardOpenOption.READ);
             workbook = new XSSFWorkbook(file);
         } catch (FileNotFoundException e) {
             e.printStackTrace();
@@ -68,7 +69,7 @@ public class XlsxExcelFile extends Excel {
     @Override
     public void save() {
         try {
-            FileOutputStream stream = new FileOutputStream(filePath);
+            OutputStream stream = Files.newOutputStream(filePath, StandardOpenOption.WRITE);
             XSSFFormulaEvaluator.evaluateAllFormulaCells(workbook);
             workbook.write(stream);
         } catch (IOException e) {
@@ -112,7 +113,7 @@ public class XlsxExcelFile extends Excel {
     /**
      * Get the currently loaded sheet of the loaded excel file.
      *
-     * @retur the current excel sheet
+     * @return the current excel sheet
      */
     @Override
     public XSSFSheet getSheet() {

--- a/src/test/java/ScaleTest.java
+++ b/src/test/java/ScaleTest.java
@@ -10,9 +10,9 @@ public class ScaleTest {
 
         String label = "a_fancy_label";
         int numericLabelValue = 1337;
-        s.appendItem(label, numericLabelValue);
+        s.appendItem(label, new CellContent(numericLabelValue));
 
-        assertEquals(numericLabelValue, s.getValueByLabel(label));
+        assertEquals(new CellContent(numericLabelValue), s.getValueByLabel(label));
     }
 
     @Test
@@ -23,42 +23,42 @@ public class ScaleTest {
         int[] values = {11, 22, 33};
 
         for (int k = 0 ; k < values.length; k++) {
-            s.appendItem(labels[k], values[k]);
+            s.appendItem(labels[k], new CellContent(values[k]));
         }
 
         for (int k = 0 ; k < values.length; k++) {
-            assertEquals(values[k], s.getValueByLabel(labels[k]));
+            assertEquals(new CellContent(values[k]), s.getValueByLabel(labels[k]));
         }
     }
 
     @Test
     public void testCannotFetchInexistentItem() {
         Scale s = new Scale();
-        assertEquals(-1, s.getValueByLabel("male"));
+        assertEquals(null, s.getValueByLabel("male"));
     }
 
     @Test
     public void testCanOnlyFetchAppendedItems() {
         Scale s = new Scale();
-        assertEquals(-1, s.getValueByLabel("male"));
-        assertEquals(-1, s.getValueByLabel("female"));
+        assertEquals(null, s.getValueByLabel("male"));
+        assertEquals(null, s.getValueByLabel("female"));
 
-        s.appendItem("female", 2);
-        s.appendItem("male", 1);
+        s.appendItem("female", new CellContent(2));
+        s.appendItem("male", new CellContent(1));
 
-        assertEquals(1, s.getValueByLabel("male"));
-        assertEquals(2, s.getValueByLabel("female"));
+        assertEquals(new CellContent(1), s.getValueByLabel("male"));
+        assertEquals(new CellContent(2), s.getValueByLabel("female"));
     }
 
     @Test
     public void testAppendItemIgnoresAddingSameItemManyTimes() {
         Scale s = new Scale();
 
-        s.appendItem("happy", 5);
-        s.appendItem("happy", 2);
-        s.appendItem("happy", 3);
-        s.appendItem("happy", 13);
+        s.appendItem("happy", new CellContent(5));
+        s.appendItem("happy", new CellContent(2));
+        s.appendItem("happy", new CellContent(3));
+        s.appendItem("happy", new CellContent(13));
 
-        assertEquals(5, s.getValueByLabel("happy"));
+        assertEquals(new CellContent(5), s.getValueByLabel("happy"));
     }
 }

--- a/src/test/java/TranslatorTest.java
+++ b/src/test/java/TranslatorTest.java
@@ -27,18 +27,18 @@ public class TranslatorTest {
 
     @Test
     public void testLookup() {
-        assertEquals(1, (int) Translator.lookup(0, "R"));
-        assertEquals(2, (int) Translator.lookup(0, "G"));
-        assertEquals(3, (int) Translator.lookup(0, "B"));
-        assertEquals(10, (int) Translator.lookup(1, "X"));
-        assertEquals(11, (int) Translator.lookup(1, "Y"));
-        assertEquals(12, (int) Translator.lookup(1, "Z"));
-        assertEquals(23, (int) Translator.lookup(2, "U"));
-        assertEquals(34, (int) Translator.lookup(2, "V"));
-        assertEquals(45, (int) Translator.lookup(2, "W"));
+        assertEquals(new CellContent(1), Translator.lookup(0, "R"));
+        assertEquals(new CellContent(2), Translator.lookup(0, "G"));
+        assertEquals(new CellContent(3), Translator.lookup(0, "B"));
+        assertEquals(new CellContent(10), Translator.lookup(1, "X"));
+        assertEquals(new CellContent(11), Translator.lookup(1, "Y"));
+        assertEquals(new CellContent(12), Translator.lookup(1, "Z"));
+        assertEquals(new CellContent(23), Translator.lookup(2, "U"));
+        assertEquals(new CellContent(34), Translator.lookup(2, "V"));
+        assertEquals(new CellContent(45), Translator.lookup(2, "W"));
 
-        assertNotEquals(1, (int) Translator.lookup(0, "G"));
-        assertNotEquals(1, (int) Translator.lookup(1, "R"));
+        assertNotEquals(1, Translator.lookup(0, "G"));
+        assertNotEquals(1, Translator.lookup(1, "R"));
     }
 
     @Test
@@ -49,12 +49,12 @@ public class TranslatorTest {
 
         int idx = 0;
         for (Scale scale : scales) {
-            int value1 = scale.getValueByLabel(gtScalaSymbols[idx]);
-            int value2 = scale.getValueByLabel(gtScalaSymbols[idx + 1]);
-            int value3 = scale.getValueByLabel(gtScalaSymbols[idx + 2]);
-            assertEquals(gtScalaValues[idx], value1);
-            assertEquals(gtScalaValues[idx + 1], value2);
-            assertEquals(gtScalaValues[idx + 2], value3);
+            CellContent value1 = scale.getValueByLabel(gtScalaSymbols[idx]);
+            CellContent value2 = scale.getValueByLabel(gtScalaSymbols[idx + 1]);
+            CellContent value3 = scale.getValueByLabel(gtScalaSymbols[idx + 2]);
+            assertEquals(new CellContent(gtScalaValues[idx]), value1);
+            assertEquals(new CellContent(gtScalaValues[idx + 1]), value2);
+            assertEquals(new CellContent(gtScalaValues[idx + 2]), value3);
             idx += 3;
         }
     }


### PR DESCRIPTION
In production use some edge cases came up such as the desire to map source cells not only to numbers but strings too (specifically the empty string) as well as the desire to automatically skip some of the mappings if some condition was fulfilled.

The latter was probably not implemented as nicely as I had originally intended to, but it made sense to me as the quickest, least complicated way to get the functionality I needed. The complexity I skipped on the program side thus shifted into the mapping and scale value files, which works for me but might make the tool less easy to use for the average person.

Another minor need was the ability to treat formula cells as blank cells in the Destination file.

I understand if you're less thrilled about the changes in this pull request, but I thought I'd bring it up anyways in case you're fine with the modifications.